### PR TITLE
prevent blocking call in event loop during SSL context creation

### DIFF
--- a/custom_components/dolphin/manifest.json
+++ b/custom_components/dolphin/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/0xAlon/dolphin",
   "issue_tracker": "https://github.com/0xAlon/dolphin",
   "codeowners": ["@0xAlon"],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
**prevent blocking call in event loop during SSL context creation**

- Moved SSL context creation to an asynchronous method create_ssl_context to avoid blocking the event loop.
- Utilized asyncio.run_in_executor to handle the blocking ssl.create_default_context call outside the event loop.
- Added async_setup method to initialize the SSL context before making network requests.
- Updated the Dolphin class initialization to align with async best practices.

This resolves warnings about blocking operations in the event loop and improves the stability of the integration.